### PR TITLE
Change googletest version to latest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "ThirdParty/googletest"]
 	path = ThirdParty/googletest
 	url = https://github.com/google/googletest.git
+	branch = main

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ sudo apt-get install libavcodec-dev libavfilter-dev libavformat-dev libavutil-de
 ## Building
 
 ```
-git clone --recurse-submodules -j8 https://github.com/apc-llc/moviemaker-cpp.git
+git clone --recurse-submodules -j8 --remote-submodules https://github.com/apc-llc/moviemaker-cpp.git
 cd moviemaker-cpp
 mkdir build
 cd build


### PR DESCRIPTION
1) This patch suggest use last googletest instead of version from 2019 which has problems with GCC 11 (example https://stackoverflow.com/questions/69935158/dummy-may-be-used-uninitialized ) 
2) add "branch = main" to fix the "Fatal: Needed a Single Revision" Error thanks https://phoenixnap.com/kb/git-pull-submodule 

Tested on clear Ubuntu 20