### PR TITLE
Remove av_register_all()

### DIFF
--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -7,20 +7,6 @@
 
 using namespace std;
 
-// One-time initialization.
-class FFmpegInitialize
-{
-public :
-
-	FFmpegInitialize()
-	{
-		// Loads the whole database of available codecs and formats.
-		av_register_all();
-	}
-};
-
-static FFmpegInitialize ffmpegInitialize;
-
 MovieWriter::MovieWriter(const string& filename_, const unsigned int width_, const unsigned int height_, const int frameRate_) :
 	
 width(width_), height(height_), iframe(0), frameRate(frameRate_),


### PR DESCRIPTION
av_register_all() - No longer used since 2018, Just delete this line. Thanks https://stackoverflow.com/a/57187224/7915017

Tested on Ubuntu 22.